### PR TITLE
Enable display of error messages

### DIFF
--- a/demo/data_control/ajax_wrapper_demo.html
+++ b/demo/data_control/ajax_wrapper_demo.html
@@ -34,6 +34,11 @@
               <ajax-wrapper data-url="https://www.random.org/integers/?num=1&min=1&max=100&col=1&base=10&format=plain" refresh-interval="5000">
                 <score-card primarycolor="#c1c1c1" icon-classes="fas fa-user" name="Total Users"></score-card>
               </ajax-wrapper>
+
+              <!-- URL returns 404 response -->
+              <ajax-wrapper data-url="http://www.mocky.io/v2/5b1691ce31000091006f3fa1" error-text="Error while loading data">
+                <score-card primarycolor="#c1c1c1" icon-classes="fas fa-user" name="Total Users"></score-card>
+              </ajax-wrapper>
             </template>
         </demo-snippet>
     </div>

--- a/demo/visualizations/fallback_text_demo.html
+++ b/demo/visualizations/fallback_text_demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>ajax-wrapper demo</title>
+
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../../src/data-control/ajax-wrapper.html">
+    <link rel="import" href="../../src/visualizations/fallback-text.html">
+    <link rel="import" href="../../src/visualizations/score-card.html">
+
+    <!-- Needs to be loaded separately for rendering of icons in components -->
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css">
+
+    <style is="custom-style" include="demo-pages-shared-styles">
+        div.vertical-section-container {
+            max-width: 1500px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="vertical-section-container centered">
+        <h3>fallback-text demo (custom element)</h3>
+        <demo-snippet>
+            <template>
+              <fallback-text data="[]" empty-data-text="No data available">
+                <score-card primarycolor="#c1c1c1" icon-classes="fas fa-user" name="Total Users"></score-card>
+              </fallback-text>
+
+              <fallback-text data="42" empty-data-text="No data available">
+                <score-card primarycolor="#c1c1c1" icon-classes="fas fa-user" name="Total Users"></score-card>
+              </fallback-text>
+            </template>
+        </demo-snippet>
+    </div>
+</body>
+
+</html>

--- a/src/all-imports.html
+++ b/src/all-imports.html
@@ -15,3 +15,4 @@
 <link rel="import" href="visualizations/loading-spinner.html">
 <link rel="import" href="visualizations/worldmap-basic.html">
 <link rel="import" href="visualizations/vennchart-basic.html">
+<link rel="import" href="visualizations/fallback-text.html">

--- a/src/data-control/ajax-wrapper.html
+++ b/src/data-control/ajax-wrapper.html
@@ -9,14 +9,25 @@ This component handles a given url by asynchronously fetching data from it and p
 -->
 <dom-module id="ajax-wrapper">
     <template>
+      <style>
+        #error-text {
+          display: block;
+        }
+      </style>
       <iron-ajax
           id="ajaxCaller"
           url="[[dataUrl]]"
           handle-as="json"
           on-response="_handleResponse"
+          on-error="_handleError"
           debounce-duration="300">
       </iron-ajax>
-      <content id="chartingElement"></content>
+      <template is="dom-if" if="[[_showErrorText]]" restamp>
+        <span id="error-text">[[errorText]]</span>
+      </template>
+      <template is="dom-if" if="[[!_showErrorText]]" restamp>
+        <content></content>
+      </template>
     </template>
     <script>
         window.addEventListener("WebComponentsReady", function() {
@@ -30,7 +41,20 @@ This component handles a given url by asynchronously fetching data from it and p
                     dataSchema: String,
                     /** If set, data is refreshed constantly after the specified interval (ms). */
                     refreshInterval:  Number,
+                    /** The text that should be shown in case of an erroneous response */
+                    errorText: {
+                        type: String,
+                        value: null,
+                    },
                     _responseData: Object,
+                    _responseError: {
+                        type: Object,
+                        value: null
+                    },
+                    _showErrorText: {
+                        type: Boolean,
+                        computed: '_computeShowErrorText(errorText, _responseError)',
+                    },
                 },
                 /** This is called by Polymer after the component instance is attached to the document. */
                 attached: function() {
@@ -47,11 +71,12 @@ This component handles a given url by asynchronously fetching data from it and p
                  * @param {Object} response The receeived response.
                  */
                 _handleResponse: function(response) {
-                    if(!response.detail.response) return;
+                    this._responseError = !response.detail.succeeded;
+                    if(this._responseError) return;
 
                     var body = JSON.parse(JSON.stringify(response.detail.response));  //we need a deep copy here. See benchmark: http://jsben.ch/#/bWfk9
                     var data = this._handlePagination(body);
-                    if(data) {
+                    if(typeof data !== 'undefined') {
                         this.publishData(this._parseData(data));
                         if(this.refreshInterval) {
                             var that = this;
@@ -68,7 +93,7 @@ This component handles a given url by asynchronously fetching data from it and p
                  * @return {Object}      The entire resources or 'undefined', if additional request is in progress.
                  */
                 _handlePagination: function(body) {
-                    if(this.dataSchema === 'jsonapi') {
+                    if(this.dataSchema === 'jsonapi' && Array.isArray(body)) {
                         this._responseData = this._responseData || [];
                         this._responseData = this._responseData.concat(body.data);
                         if(body.links.next) {
@@ -91,14 +116,20 @@ This component handles a given url by asynchronously fetching data from it and p
                  * @return {Object}      The parsed data.
                  */
                 _parseData: function(data) {
-                    if(this.dataSchema === 'jsonapi') {
+                    if(this.dataSchema === 'jsonapi' && Array.isArray(data)) {
                         return data.map(function(resource) {
                             return resource.attributes;
                         });
                     }
 
                     return data;
-                }
+                },
+                _handleError: function() {
+                    this._responseError = true;
+                },
+                _computeShowErrorText: function(errorText, responseError) {
+                    return typeof errorText !== 'undefined' && responseError;
+                },
             });
         });
     </script>

--- a/src/visualizations/fallback-text.html
+++ b/src/visualizations/fallback-text.html
@@ -1,0 +1,53 @@
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../behaviors/data-transformer-behavior.html">
+
+
+<!--
+`fallback-text`
+<br />This component is used as wrapper of actual visualization components for displaying a fallback text if received data is empty.
+
+@demo demo/visualizations/fallback_text_demo.html
+-->
+<dom-module id="fallback-text">
+    <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <template is="dom-if" if="[[_hasEmptyData]]">
+      <span>[[emptyDataText]]</span>
+    </template>
+    <template is="dom-if" if="[[!_hasEmptyData]]">
+      <content></content>
+    </template>
+  </template>
+    <script>
+        window.addEventListener("WebComponentsReady", function(){
+        Polymer({
+            is: 'fallback-text',
+            behaviors: [DataTransformerBehavior],
+            properties: {
+                emptyDataText: String,
+                _hasEmptyData: {
+                    type: Boolean,
+                    computed: '_computeHasEmptyData(hasReceivedData, data)',
+                },
+            },
+            _computeHasEmptyData: function(hasReceivedData, data) {
+                if(!hasReceivedData) {
+                    return false;
+                }
+                if(Array.isArray(data)) {
+                    return data.length === 0;
+                }
+                if(data !== null && typeof data === 'object') {
+                    return Object.keys(data).length === 0;
+                }
+
+                return typeof data === 'undefined' || data === null;
+            },
+        });
+     });
+    </script>
+</dom-module>


### PR DESCRIPTION
This PR adds possibility to show custom messages in case of request errors or empty data. 

The `ajax-wrapper` is extended by the new optional property `errorText.` If set, the text is displayed if AJAX request has failed.

The component `fallback-text` is added and shall be used as a wrapper for a concrete visualization. It displays a configured message if received data is empty (either empty array, object without keys, `null`, or `undefined`).