### PR TITLE
Minor fixes and enhancements

### DIFF
--- a/src/behaviors/data-transformer-behavior.html
+++ b/src/behaviors/data-transformer-behavior.html
@@ -14,7 +14,12 @@
          * @param  {Object} data The received data.
          */
         dataChanged: function(data) {
-            this.passData(this.transformData(data));
+          try {
+            data = this.transformData(data);
+          } catch(e) {
+            console.error(e);
+          }
+          this.passData(data);
         },
         /**
          * Applies the transformation. Needs to be implemented by the concrete component.

--- a/src/data-control/ajax-wrapper.html
+++ b/src/data-control/ajax-wrapper.html
@@ -126,6 +126,7 @@ This component handles a given url by asynchronously fetching data from it and p
                 },
                 _handleError: function() {
                     this._responseError = true;
+                    this.publishData(null);
                 },
                 _computeShowErrorText: function(errorText, responseError) {
                     return errorText !== null && responseError;

--- a/src/data-control/ajax-wrapper.html
+++ b/src/data-control/ajax-wrapper.html
@@ -128,7 +128,7 @@ This component handles a given url by asynchronously fetching data from it and p
                     this._responseError = true;
                 },
                 _computeShowErrorText: function(errorText, responseError) {
-                    return typeof errorText !== 'undefined' && responseError;
+                    return errorText !== null && responseError;
                 },
             });
         });


### PR DESCRIPTION
This PR fixes a bug causing children of `ajax-wrapper` elements to be hidden in case of request errors if not error text is specified. 

Additionally, error handling was improved: `ajax-wrapper` elements now pass `null` to descendant elements in case of request errors to indicate that the request has been completed, but failed. Besides, if an error occurs during transformation of data in transformer elements, the original data is passed to descendants.